### PR TITLE
[CHORE] User배송담당자 HUB일경우 NULL 허용되게 변경

### DIFF
--- a/module-user/src/main/java/org/sparta/user/application/service/UserService.java
+++ b/module-user/src/main/java/org/sparta/user/application/service/UserService.java
@@ -1,11 +1,11 @@
 package org.sparta.user.application.service;
 
+import jakarta.validation.constraints.Null;
 import lombok.RequiredArgsConstructor;
 import org.sparta.common.error.BusinessException;
 import org.sparta.common.event.EventPublisher;
 import org.sparta.user.domain.entity.User;
-import org.sparta.user.domain.enums.UserRoleEnum;
-import org.sparta.user.domain.enums.UserStatusEnum;
+import org.sparta.user.domain.enums.*;
 import org.sparta.user.domain.error.UserErrorType;
 import org.sparta.user.domain.repository.UserRepository;
 import org.sparta.user.infrastructure.event.publisher.UserCreatedEvent;
@@ -63,19 +63,20 @@ public class UserService {
         String slackId = request.slackId();
         UUID hubId = request.hubId();
         UserRoleEnum role = request.role();
+        DeliveryManagerRoleEnum deliveryManagerRoleEnum = request.deliveryRole();
 
         // 중복 체크: userName, email
         userRepository.findByUserName(userName).ifPresent(u -> {
-            throw new BusinessException(UserErrorType.UNAUTHORIZED, "중복된 사용자 ID가 존재합니다.");
+            throw new BusinessException(UserErrorType.VALIDATION_FAILED, "중복된 사용자 ID가 존재합니다.");
         });
         userRepository.findByEmail(email).ifPresent(u -> {
-            throw new BusinessException(UserErrorType.UNAUTHORIZED,"중복된 Email 입니다.");
+            throw new BusinessException(UserErrorType.VALIDATION_FAILED,"중복된 Email 입니다.");
         });
 
         // 사용자 생성 및 저장
         User user = User.create(
                 userName, password, slackId, realName,
-                userPhoneNumber, email, role, hubId);
+                userPhoneNumber, email, role, hubId, deliveryManagerRoleEnum);
 
         user = userRepository.save(user);
 

--- a/module-user/src/main/java/org/sparta/user/domain/entity/User.java
+++ b/module-user/src/main/java/org/sparta/user/domain/entity/User.java
@@ -3,6 +3,7 @@ package org.sparta.user.domain.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.sparta.common.error.BusinessException;
+import org.sparta.user.domain.enums.DeliveryManagerRoleEnum;
 import org.sparta.user.domain.enums.UserRoleEnum;
 import org.sparta.user.domain.enums.UserStatusEnum;
 import org.sparta.jpa.entity.BaseEntity;
@@ -47,12 +48,13 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 30)
     private UserRoleEnum role; // 사용자 역할
 
-    @Column(name = "hub_id", nullable = false)
+    @Column(name = "hub_id")
     private UUID hubId; // 허브 UUID (회원가입 시 소속 허브 필요)
 
     /**
-     * 주문 생성 팩토리 메서드
+     * 유저 생성 팩토리 메서드
      * 모든 비즈니스 규칙을 여기서 검증
+     * DeliveryManager에 따라 오버라이딩
      */
     public static User create(
             String userName, String password, String slackId, String realName,
@@ -60,7 +62,34 @@ public class User extends BaseEntity {
 
         // 비즈니스 규칙 검증
         validateUserName(userName);
-        validateHubId(hubId);
+        validateHubId(hubId); // DeliveryManager-HUB면 허브Id Null되도록
+        validatePassword(password);
+        validateSlackId(slackId);
+        validateEmail(email);
+
+        // User 엔티티 생성
+        User user = new User();
+        user.userName = userName;
+        user.password = password;
+        user.slackId = slackId;
+        user.realName = realName;
+        user.userPhoneNumber = userPhoneNumber;
+        user.email = email;
+        user.status = UserStatusEnum.PENDING;
+        user.role = role;
+        user.hubId = hubId;
+
+        return user;
+    }
+
+    public static User create(
+            String userName, String password, String slackId, String realName,
+            String userPhoneNumber, String email, UserRoleEnum role, UUID hubId,
+            DeliveryManagerRoleEnum deliveryManagerRoleEnum) {
+
+        // 비즈니스 규칙 검증
+        validateUserName(userName);
+        hubId = validateHubId(role, deliveryManagerRoleEnum, hubId); // DeliveryManager-HUB면 허브Id Null되도록
         validatePassword(password);
         validateSlackId(slackId);
         validateEmail(email);
@@ -109,8 +138,23 @@ public class User extends BaseEntity {
 
     private static void validateHubId(UUID hubId) {
         if (hubId == null) {
-            throw new BusinessException(UserErrorType.HUB_ID_REQUIRED);
+            throw new BusinessException(UserErrorType.SLACK_ID_REQUIRED);
         }
+    }
+
+    private static UUID validateHubId(UserRoleEnum role,
+                                      DeliveryManagerRoleEnum deliveryManagerRole, UUID hubId) {
+        if(role == UserRoleEnum.DELIVERY_MANAGER) {
+            if(deliveryManagerRole == DeliveryManagerRoleEnum.HUB) {
+                hubId = null;
+            }
+        }
+        else {
+            if(hubId == null) {
+                throw new BusinessException(UserErrorType.HUB_ID_REQUIRED);
+            }
+        }
+        return hubId;
     }
 
     public void updateUserName(String userName) {this.userName = userName;}

--- a/module-user/src/main/java/org/sparta/user/domain/enums/DeliveryManagerRoleEnum.java
+++ b/module-user/src/main/java/org/sparta/user/domain/enums/DeliveryManagerRoleEnum.java
@@ -1,0 +1,6 @@
+package org.sparta.user.domain.enums;
+
+public enum DeliveryManagerRoleEnum {
+    HUB,        // 허브 배송 담당자
+    COMPANY     // 업체 배송 담당자
+}

--- a/module-user/src/main/java/org/sparta/user/presentation/UserRequest.java
+++ b/module-user/src/main/java/org/sparta/user/presentation/UserRequest.java
@@ -2,6 +2,7 @@ package org.sparta.user.presentation;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
+import org.sparta.user.domain.enums.DeliveryManagerRoleEnum;
 import org.sparta.user.domain.enums.UserRoleEnum;
 
 import java.util.UUID;
@@ -39,8 +40,10 @@ public class UserRequest {
             @NotNull
             UserRoleEnum role,
 
+            @Schema(description = "배송 담당자 종류", example = "HUB")
+            DeliveryManagerRoleEnum deliveryRole, // DELIVERY_MANAGER일때만 유효
+
             @Schema(description = "허브 ID", example = "61a98cf7-921c-47fb-a802-3ec71f736f74")
-            @NotNull
             UUID hubId
     ) {
     }
@@ -84,8 +87,10 @@ public class UserRequest {
             @NotNull
             UserRoleEnum role,
 
+            @Schema(description = "배송 담당자 종류", example = "HUB")
+            DeliveryManagerRoleEnum deliveryRole, // DELIVERY_MANAGER일때만 유효
+
             @Schema(description = "허브 ID", example = "61a98cf7-921c-47fb-a802-3ec71f736f74")
-            @NotNull
             UUID hubId
     ) {
     }

--- a/module-user/src/test/java/org/sparta/user/application/UserServiceTest.java
+++ b/module-user/src/test/java/org/sparta/user/application/UserServiceTest.java
@@ -10,6 +10,7 @@ import org.sparta.common.error.BusinessException;
 import org.sparta.common.event.EventPublisher;
 import org.sparta.user.application.service.UserService;
 import org.sparta.user.domain.entity.User;
+import org.sparta.user.domain.enums.DeliveryManagerRoleEnum;
 import org.sparta.user.domain.enums.UserRoleEnum;
 import org.sparta.user.domain.enums.UserStatusEnum;
 import org.sparta.user.domain.repository.UserRepository;
@@ -72,7 +73,7 @@ public class UserServiceTest {
         // given
         UserRequest.SignUpUser request = new UserRequest.SignUpUser(
                 "newUser", "password123", "slackId", "홍길동",
-                "01012341234", "new@ex.com", UserRoleEnum.MASTER, hubId
+                "01012341234", "new@ex.com", UserRoleEnum.MASTER, DeliveryManagerRoleEnum.COMPANY, hubId
         );
 
         given(userRepository.findByUserName("newUser")).willReturn(Optional.empty());
@@ -96,7 +97,7 @@ public class UserServiceTest {
         // given
         UserRequest.SignUpUser request = new UserRequest.SignUpUser(
                 "dupUser", "pw", "slackId", "홍길동",
-                "01012345678", "dup@ex.com", UserRoleEnum.DELIVERY_MANAGER, hubId
+                "01012345678", "dup@ex.com", UserRoleEnum.DELIVERY_MANAGER, DeliveryManagerRoleEnum.COMPANY, hubId
         );
         given(userRepository.findByUserName("dupUser")).willReturn(Optional.of(mock(User.class)));
 

--- a/module-user/src/test/java/org/sparta/user/application/event/UserEventPublisherTest.java
+++ b/module-user/src/test/java/org/sparta/user/application/event/UserEventPublisherTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sparta.common.event.EventPublisher;
 import org.sparta.user.application.service.UserService;
 import org.sparta.user.domain.entity.User;
+import org.sparta.user.domain.enums.DeliveryManagerRoleEnum;
 import org.sparta.user.domain.enums.UserRoleEnum;
 import org.sparta.user.domain.repository.UserRepository;
 import org.sparta.user.infrastructure.event.publisher.UserCreatedEvent;
@@ -54,7 +55,7 @@ class UserEventPublisherTest {
         // given
         UserRequest.SignUpUser request = new UserRequest.SignUpUser(
                 "newUser", "password123", "slackId", "홍길동",
-                "01012341234", "new@ex.com", UserRoleEnum.MASTER, hubId
+                "01012341234", "new@ex.com", UserRoleEnum.MASTER, DeliveryManagerRoleEnum.COMPANY, hubId
         );
         given(userRepository.findByUserName("newUser")).willReturn(Optional.empty());
         given(userRepository.findByEmail("new@ex.com")).willReturn(Optional.empty());

--- a/module-user/src/test/java/org/sparta/user/e2e/UserApiIntegrationTest.java
+++ b/module-user/src/test/java/org/sparta/user/e2e/UserApiIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sparta.common.event.EventPublisher;
 import org.sparta.user.UserApplication;
+import org.sparta.user.domain.enums.DeliveryManagerRoleEnum;
 import org.sparta.user.domain.enums.UserRoleEnum;
 import org.sparta.user.infrastructure.SecurityDisabledConfig;
 import org.sparta.user.presentation.UserRequest;
@@ -55,7 +56,7 @@ class UserApiIntegrationTest {
         // 1. 회원가입
         UserRequest.SignUpUser signupRequest = new UserRequest.SignUpUser(
                 "e2eUser", "pw123!", "slack01", "홍길동",
-                "01011112222", "e2e@test.com", UserRoleEnum.MASTER, hubId
+                "01011112222", "e2e@test.com", UserRoleEnum.MASTER, DeliveryManagerRoleEnum.COMPANY, hubId
         );
 
         String userId = given()

--- a/module-user/src/test/java/org/sparta/user/presentation/UserControllerTest.java
+++ b/module-user/src/test/java/org/sparta/user/presentation/UserControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.sparta.user.application.service.UserService;
+import org.sparta.user.domain.enums.DeliveryManagerRoleEnum;
 import org.sparta.user.domain.enums.UserRoleEnum;
 import org.sparta.user.domain.enums.UserStatusEnum;
 import org.sparta.user.infrastructure.SecurityDisabledConfig;
@@ -65,7 +66,7 @@ class UserControllerTest {
 
         UserRequest.SignUpUser request = new UserRequest.SignUpUser(
                 "testuser", "pw123!", "slack01", "홍길동",
-                "01011112222", "test@ex.com", UserRoleEnum.MASTER, hubId
+                "01011112222", "test@ex.com", UserRoleEnum.MASTER, DeliveryManagerRoleEnum.COMPANY, hubId
         );
 
         // when & then
@@ -83,7 +84,7 @@ class UserControllerTest {
         // given: email 누락
         UserRequest.SignUpUser invalidRequest = new UserRequest.SignUpUser(
                 "testuser", "pw123!", "slack01", "홍길동",
-                "01011112222", "", UserRoleEnum.MASTER, UUID.randomUUID()
+                "01011112222", "", UserRoleEnum.MASTER, DeliveryManagerRoleEnum.COMPANY, UUID.randomUUID()
         );
 
         // when & then


### PR DESCRIPTION
## 변경 사항
<!-- 팀원과 반드시 공유되어야하는 사항을 간단하게 작성해주세요 -->

---

배송담당자 HubId를 허용하기 위해서 DB Table의 hubId가 Null이 허용되고, 서비스에서 Null을 막도록 변경하였기 때문에
기존 User Table이 Local에 남아있다면 한 번 지우셔야 합니다

## 관련 이슈
<!-- 관련된 이슈 번호가 있다면 작성해주세요 -->

---

PR Merges시 자동으로 해당 Issue를 닫습니다. (예: close #123)

close #106 

## 스크린샷 (선택사항)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 사용자 가입 및 업데이트 시 배송 관리자 역할(HUB 또는 COMPANY)을 지정할 수 있습니다.
  * 배송 관리자 역할이 HUB인 경우 허브 ID가 자동으로 관리됩니다.

* **버그 수정**
  * 사용자 이름 및 이메일 중복 검증 실패 시 오류 처리가 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->